### PR TITLE
Host can fill in listing form

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -1,6 +1,7 @@
 class ListingsController < ApplicationController
 
   def new
+    @listing
   end
 
 end

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -1,6 +1,6 @@
 class ListingsController < ApplicationController
 
-def new
-end
+  def new
+  end
 
 end

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -1,0 +1,6 @@
+class ListingsController < ApplicationController
+
+def new
+end
+
+end

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -4,7 +4,7 @@ class ListingsController < ApplicationController
   end
 
   def new
-    @listing
+    @listing = Listing.new
   end
 
 end

--- a/app/views/listings/new.html.haml
+++ b/app/views/listings/new.html.haml
@@ -1,0 +1,1 @@
+%h1 Create new listing

--- a/app/views/listings/new.html.haml
+++ b/app/views/listings/new.html.haml
@@ -1,1 +1,29 @@
 %h1 Create new listing
+
+
+= form_with model: @listing, local: true do |form|
+  %p
+    = form.label :Name
+    %br/
+    = form.text_field :name
+  %p
+    = form.label :content
+    %br/
+    = form.text_area :content
+  %p
+    = form.submit
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/app/views/listings/new.html.haml
+++ b/app/views/listings/new.html.haml
@@ -3,27 +3,27 @@
 
 = form_with model: @listing, local: true do |form|
   %p
-    = form.label :Name
+    = form.label :name
     %br/
     = form.text_field :name
   %p
-    = form.label :Location
+    = form.label :location
     %br/
     = form.text_field :location
   %p
-    = form.label :Description
+    = form.label :description
     %br/
     = form.text_area :description  
   %p
-    = form.label :Availability
+    = form.label :availability
     %br/
     = form.text_field :availability
   %p
-    = form.label :Email
+    = form.label :email
     %br/
     = form.email_field :email
   %p
-    = form.label :"Phone number"
+    = form.label :phone_number
     %br/
     = form.telephone_field :phone_number
   %p

--- a/app/views/listings/new.html.haml
+++ b/app/views/listings/new.html.haml
@@ -25,6 +25,6 @@
   %p
     = form.label :"Phone number"
     %br/
-    = form.telephone_field :"phone number"
+    = form.telephone_field :phone_number
   %p
     = form.submit "Create Listing"

--- a/app/views/listings/new.html.haml
+++ b/app/views/listings/new.html.haml
@@ -27,4 +27,4 @@
     %br/
     = form.telephone_field :"phone number"
   %p
-    = form.submit
+    = form.submit "Create Listing"

--- a/app/views/listings/new.html.haml
+++ b/app/views/listings/new.html.haml
@@ -7,23 +7,24 @@
     %br/
     = form.text_field :name
   %p
-    = form.label :content
+    = form.label :Location
     %br/
-    = form.text_area :content
+    = form.text_field :location
+  %p
+    = form.label :Description
+    %br/
+    = form.text_area :description  
+  %p
+    = form.label :Availability
+    %br/
+    = form.text_field :availability
+  %p
+    = form.label :Email
+    %br/
+    = form.email_field :email
+  %p
+    = form.label :"Phone number"
+    %br/
+    = form.telephone_field :"phone number"
   %p
     = form.submit
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resources :listings
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  resources :listings
+  resources :listings, only: [:new]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   root controller: :listings, action: :index
-  resources :listings, only: [:new]
+  resources :listings, only: [:new, :create]
 end

--- a/features/host_can_fill_listing_form.feature
+++ b/features/host_can_fill_listing_form.feature
@@ -6,7 +6,7 @@ Feature: Host can fill in a listing form
   Scenario: Host can succesully view and fill in all fields in a listing form, without creating it
     Given I visit the "Become a host" page
     Then I should see "Create new listing"
-    And I fill in "Name" with "George"
+    And I fill in "name" with "George"
     And I fill in "Location" with "Stockholm"
     And I fill in "Description" with "Hello, please lend me your cat"
     And I fill in "Availability" with "All summer"

--- a/features/host_can_fill_listing_form.feature
+++ b/features/host_can_fill_listing_form.feature
@@ -4,7 +4,7 @@ Feature: Host can fill in a listing form
   I need to be able to fill in a listing form.
 
   Scenario: Host can succesully view and fill in all fields in a listing form, without creating it
-    Given I visit the "Become a host" page
+    Given I visit the Become a host page
     Then I should see "Create new listing"
     And I fill in "name" with "George"
     And I fill in "location" with "Stockholm"

--- a/features/host_can_fill_listing_form.feature
+++ b/features/host_can_fill_listing_form.feature
@@ -11,7 +11,7 @@ Feature: Host can fill in a listing form
     And I fill in "description" with "Hello, please lend me your cat"
     And I fill in "availability" with "All summer"
     And I fill in "email" with "george@craft.se"
-    And I fill in "phone number" with "07071234567"
+    And I fill in "phone_number" with "07071234567"
     And I should see "Create Listing" button
     Then I should not see "listing was created succesfully"
     

--- a/features/host_can_fill_listing_form.feature
+++ b/features/host_can_fill_listing_form.feature
@@ -5,6 +5,7 @@ Feature: Host can fill in a listing form
 
   Scenario: Host can succesully view and fill in all fields in a listing form, without creating it
     Given I visit the "Become a host" page
+    Then I should see "Create new listing"
     And I fill in "Name" with "George"
     And I fill in "Location" with "Stockholm"
     And I fill in "Description" with "Hello, please lend me your cat"

--- a/features/host_can_fill_listing_form.feature
+++ b/features/host_can_fill_listing_form.feature
@@ -1,0 +1,15 @@
+Feature: Host can fill in a listing form 
+  As a Host,
+  In order to display information about myself,
+  I need to be able to fill in a listing form.
+
+  Scenario: Host can succesully view and fill in all fields in a listing form, without creating it
+    Given I visit the "Become a host" page
+    And I fill in "Name" with "George"
+    And I fill in "Location" with "Stockholm"
+    And I fill in "Description" with "Hello, please lend me your cat"
+    And I fill in "Availability" with "All summer"
+    And I fill in "Email" with "george@craft.se"
+    And I fill in "Phone number" with "07071234567"
+    And click "Create listing"
+    Then I should not see "listing was created succesfully"

--- a/features/host_can_fill_listing_form.feature
+++ b/features/host_can_fill_listing_form.feature
@@ -13,5 +13,4 @@ Feature: Host can fill in a listing form
     And I fill in "email" with "george@craft.se"
     And I fill in "phone_number" with "07071234567"
     And I should see "Create Listing" button
-    Then I should not see "listing was created succesfully"
     

--- a/features/host_can_fill_listing_form.feature
+++ b/features/host_can_fill_listing_form.feature
@@ -6,11 +6,11 @@ Feature: Host can fill in a listing form
   Scenario: Host can succesully view and fill in all fields in a listing form, without creating it
     Given I visit the Become a host page
     Then I should see "Create new listing"
-    And I fill in "name" with "George"
-    And I fill in "location" with "Stockholm"
-    And I fill in "description" with "Hello, please lend me your cat"
-    And I fill in "availability" with "All summer"
-    And I fill in "email" with "george@craft.se"
-    And I fill in "phone_number" with "07071234567"
+    And I fill in "Name" with "George"
+    And I fill in "Location" with "Stockholm"
+    And I fill in "Description" with "Hello, please lend me your cat"
+    And I fill in "Availability" with "All summer"
+    And I fill in "Email" with "george@craft.se"
+    And I fill in "Phone number" with "07071234567"
     And I should see "Create Listing" button
     

--- a/features/host_can_fill_listing_form.feature
+++ b/features/host_can_fill_listing_form.feature
@@ -13,3 +13,4 @@ Feature: Host can fill in a listing form
     And I fill in "Phone number" with "07071234567"
     And click "Create listing"
     Then I should not see "listing was created succesfully"
+    

--- a/features/host_can_fill_listing_form.feature
+++ b/features/host_can_fill_listing_form.feature
@@ -12,6 +12,6 @@ Feature: Host can fill in a listing form
     And I fill in "availability" with "All summer"
     And I fill in "email" with "george@craft.se"
     And I fill in "phone number" with "07071234567"
-    And click "Create listing"
+    And I should see "Create Listing" button
     Then I should not see "listing was created succesfully"
     

--- a/features/host_can_fill_listing_form.feature
+++ b/features/host_can_fill_listing_form.feature
@@ -7,11 +7,11 @@ Feature: Host can fill in a listing form
     Given I visit the "Become a host" page
     Then I should see "Create new listing"
     And I fill in "name" with "George"
-    And I fill in "Location" with "Stockholm"
-    And I fill in "Description" with "Hello, please lend me your cat"
-    And I fill in "Availability" with "All summer"
-    And I fill in "Email" with "george@craft.se"
-    And I fill in "Phone number" with "07071234567"
+    And I fill in "location" with "Stockholm"
+    And I fill in "description" with "Hello, please lend me your cat"
+    And I fill in "availability" with "All summer"
+    And I fill in "email" with "george@craft.se"
+    And I fill in "phone number" with "07071234567"
     And click "Create listing"
     Then I should not see "listing was created succesfully"
     

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -1,3 +1,7 @@
+Then("I should see {string}") do |content|
+  expect(page).to have_content content
+end
+
 Then("I should not see {string}") do |string|
   pending # Write code here that turns the phrase above into concrete actions
 end

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -5,3 +5,7 @@ end
 Then("I should not see {string}") do |content|
   expect(page).to have_no_content content
 end
+
+Then("I should see {string} button") do |button|
+  expect(page).to have_button(button)
+end

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -1,0 +1,3 @@
+Then("I should not see {string}") do |string|
+  pending # Write code here that turns the phrase above into concrete actions
+end

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -2,10 +2,6 @@ Then("I should see {string}") do |content|
   expect(page).to have_content content
 end
 
-Then("I should not see {string}") do |content|
-  expect(page).to have_no_content content
-end
-
 Then("I should see {string} button") do |button|
   expect(page).to have_button(button)
 end

--- a/features/step_definitions/assertion_steps.rb
+++ b/features/step_definitions/assertion_steps.rb
@@ -2,6 +2,6 @@ Then("I should see {string}") do |content|
   expect(page).to have_content content
 end
 
-Then("I should not see {string}") do |string|
-  pending # Write code here that turns the phrase above into concrete actions
+Then("I should not see {string}") do |content|
+  expect(page).to have_no_content content
 end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -1,4 +1,4 @@
-Given("I visit the {string} page") do |string|
+Given("I visit the Become a host page") do
   visit new_listing_path
 end
 

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -1,5 +1,5 @@
 Given("I visit the {string} page") do |string|
-  pending # Write code here that turns the phrase above into concrete actions
+  visit new_listing_path
 end
 
 When("I fill in {string} with {string}") do |string, string2|

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -5,7 +5,3 @@ end
 When("I fill in {string} with {string}") do |field, content|
   fill_in field, with: content
 end
-
-Then("I should see {string} button") do |button|
-  expect(page).to have_button(button)
-end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -6,6 +6,6 @@ When("I fill in {string} with {string}") do |field, content|
   fill_in field, with: content
 end
 
-When("click {string}") do |string|
-  pending # Write code here that turns the phrase above into concrete actions
+Then("I should see {string} button") do |button|
+  expect(page).to have_button(button)
 end

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -2,8 +2,8 @@ Given("I visit the {string} page") do |string|
   visit new_listing_path
 end
 
-When("I fill in {string} with {string}") do |string, string2|
-  pending # Write code here that turns the phrase above into concrete actions
+When("I fill in {string} with {string}") do |field, content|
+  fill_in field, with: content
 end
 
 When("click {string}") do |string|

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -1,0 +1,11 @@
+Given("I visit the {string} page") do |string|
+  pending # Write code here that turns the phrase above into concrete actions
+end
+
+When("I fill in {string} with {string}") do |string, string2|
+  pending # Write code here that turns the phrase above into concrete actions
+end
+
+When("click {string}") do |string|
+  pending # Write code here that turns the phrase above into concrete actions
+end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/165811906)
## Changes proposed in this pull request:
* Creates feature test for viewing and filling in form for new "listing" 
* Adding step definitions to two new files: "basic_steps.rb" and "assertion_steps.rb"  
* Generates controller for "Listings", and defines "new" method   
* Creates resources/routes for "listing"
* Creates "new.html.haml" view with input form

## What I have learned working on this feature:
* "form_with" functionality for Rails
* writing test for finding buttons, but not clicking them

<img width="375" alt="Screenshot 2019-05-07 at 09 40 45" src="https://user-images.githubusercontent.com/48205436/57282126-b3847900-70ac-11e9-9fe8-1b25da121c1a.png">
